### PR TITLE
[DE-23] Developed a reusable button component for two brands

### DIFF
--- a/ComponentLibrary/Components/ButtonComponent.swift
+++ b/ComponentLibrary/Components/ButtonComponent.swift
@@ -1,0 +1,190 @@
+//
+//  ButtonComponent.swift
+//  ComponentLibrary
+//
+//  Created by UI/UX Development Team on 2/4/25.
+//
+
+import SwiftUI
+
+// MARK: - Supporting Types
+
+enum ButtonVariant {
+    case primary
+    case secondary
+    case tertiary
+    case disabled
+}
+
+enum ButtonSize {
+    case `default`
+    case small
+}
+
+// Optional: Using an enum for brand improves type safety:
+enum Brand: String {
+    case de = "brandDE"
+    case reliant = "brandReliant"
+}
+
+// A simple type-erased Shape to allow different shapes in one property.
+struct AnyShape: Shape {
+    // Mark the closure as @Sendable
+    private let pathClosure: @Sendable (CGRect) -> Path
+
+    init<S: Shape>(_ shape: S) {
+        // Annotate the closure as @Sendable when initializing
+        self.pathClosure = { @Sendable rect in
+            shape.path(in: rect)
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        pathClosure(rect)
+    }
+}
+
+
+// MARK: - Unified Button Component
+
+struct ButtonComponent: View {
+    @Environment(\.colorScheme) var colorScheme
+
+    let selectedBrand: Brand
+    let title: String
+    let variant: ButtonVariant
+    let size: ButtonSize
+    var action: () -> Void = {}
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .typographyStyle(buttonTypographyStyle, brand: selectedBrand.rawValue)
+                // Apply underline for tertiary variant For brandD
+                .modifier(UnderlineModifier(applyUnderline: selectedBrand == .de && variant == .tertiary, color: foregroundColor))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, verticalPadding)
+        }
+        .frame(maxWidth: size == .default ? .infinity : 156)
+        .background(
+            backgroundShape
+                .fill(backgroundColor)
+        )
+        .brandBorderOverlay(
+            brand: selectedBrand.rawValue,
+            radiusKey: selectedBrand == .de ? .s : .full,
+            strokeKey: .regular,
+            color: borderColor
+        )
+        .foregroundColor(foregroundColor)
+    }
+
+    // MARK: - Computed Properties
+
+    private var buttonTypographyStyle: MyTextStyle {
+        return .primaryButton
+    }
+
+    
+    private var verticalPadding: CGFloat {
+        // DE uses 16; Reliant uses 15.
+        return selectedBrand == .de ? 16 : 15
+    }
+    
+    private var backgroundShape: AnyShape {
+        // DE uses a RoundedRectangle; Reliant uses a Capsule.
+        if selectedBrand == .de {
+            return AnyShape(RoundedRectangle(cornerRadius: 4))
+        } else {
+            return AnyShape(Capsule())
+        }
+    }
+    
+    private var backgroundColor: Color {
+        switch selectedBrand {
+        case .de:
+            switch variant {
+            case .primary:
+                return ColorToken.containerFillTertiaryBrand.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .secondary:
+                return ColorToken.containerFillGrayDefault.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .tertiary:
+                return ColorToken.grayscale000.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .disabled:
+                return ColorToken.grayscale300.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            }
+        case .reliant:
+            switch variant {
+            case .primary:
+                return ColorToken.primaryBase.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .secondary:
+                return ColorToken.primaryLightest.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .tertiary:
+                return ColorToken.grayscale000.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .disabled:
+                return ColorToken.grayscale400.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            }
+        }
+    }
+    
+    private var foregroundColor: Color {
+        switch selectedBrand {
+        case .de:
+            switch variant {
+            case .primary, .secondary, .tertiary:
+                return ColorToken.grayscale900.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .disabled:
+                return ColorToken.grayscale600.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            }
+        case .reliant:
+            switch variant {
+            case .primary:
+                return ColorToken.grayscale000.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .secondary, .tertiary:
+                return ColorToken.primaryBase.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .disabled:
+                return ColorToken.grayscale600.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            }
+        }
+    }
+    
+    private var borderColor: Color {
+        switch selectedBrand {
+        case .de:
+            switch variant {
+            case .primary, .secondary:
+                return ColorToken.grayscale900.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .tertiary:
+                return .clear
+            case .disabled:
+                return ColorToken.grayscale300.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            }
+        case .reliant:
+            switch variant {
+            case .primary:
+                return ColorToken.primaryBase.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .secondary:
+                return ColorToken.primaryLightest.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .tertiary:
+                return ColorToken.primaryBase.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            case .disabled:
+                return ColorToken.grayscale300.color(brand: selectedBrand.rawValue, colorScheme: colorScheme)
+            }
+        }
+    }
+}
+
+// MARK: - Underline Modifier (for brandDE tertiary buttons)
+
+struct UnderlineModifier: ViewModifier {
+    let applyUnderline: Bool
+    let color: Color
+
+    func body(content: Content) -> some View {
+        if applyUnderline {
+            content.underline(true, color: color)
+        } else {
+            content
+        }
+    }
+}

--- a/ComponentLibrary/Components/ButtonView.swift
+++ b/ComponentLibrary/Components/ButtonView.swift
@@ -1,0 +1,123 @@
+//
+//  ButtonView.swift
+//  ComponentLibrary
+//
+//  Created by UI/UX Development Team on 2/4/25.
+//
+
+import SwiftUI
+
+struct ButtonView: View {
+    @State private var showToast = false
+    @Environment(\.colorScheme) var colorScheme
+//        @State private var selectedBrand: Brand = .de
+    @State private var selectedBrand: Brand = .reliant
+    
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                VStack(spacing: 14) {
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Button show toast",
+                        variant: .primary,
+                        size: .default
+                    ) {
+                        withAnimation {
+                            showToast = true
+                        }
+                    }
+                    
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Button",
+                        variant: .secondary,
+                        size: .default
+                    ) {
+                        print("Secondary tapped")
+                    }
+                    
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Button",
+                        variant: .tertiary,
+                        size: .default
+                    ) {
+                        print("Tertiary tapped")
+                    }
+                    
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Button",
+                        variant: .disabled,
+                        size: .default
+                    )
+                    
+                    // Small-sized buttons
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Small Button",
+                        variant: .primary,
+                        size: .small
+                    ) {
+                        print("Small Primary tapped")
+                    }
+                    
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Small Button",
+                        variant: .secondary,
+                        size: .small
+                    ) {
+                        print("Small Primary tapped")
+                    }
+                    
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Small Button",
+                        variant: .tertiary,
+                        size: .small
+                    ) {
+                        print("Small Primary tapped")
+                    }
+                    
+                    ButtonComponent(
+                        selectedBrand: selectedBrand,
+                        title: "Small Button",
+                        variant: .disabled,
+                        size: .small
+                    )
+                }
+                .padding()
+                .frame(minHeight: geometry.size.height)
+            }
+            .overlay(
+                VStack {
+                    
+                    ToastView(
+                        message: "Complete your Vivint offer by scheduling your installation.",
+                        linkText: Text("Schedule installation")
+                            .font(.subheadline)
+                            .foregroundColor(ColorToken.grayscale000.color(brand: "brandReliant", colorScheme: colorScheme)),
+                        linkAction: {
+                            print("Link tapped")
+                        },
+                        image: Image("doorbell"),
+                        backgroundColor: ColorToken.grayscale800.color(brand: "brandReliant", colorScheme: colorScheme),
+                        duration: 60.0,
+                        isVisible: $showToast
+                    )
+                    
+                    .animation(.easeInOut, value: showToast)
+                }
+            )
+        }
+    }
+}
+
+struct ButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+        ButtonView()
+    }
+}


### PR DESCRIPTION
**Features**:

- Integrated previously built color, typography, and border system into the button component.
- A single button component supports both brand styles by switching the brand name.
- Supports primary, secondary, tertiary, and disabled states in both default and small sizes, based on the Figma design.
- The default button width automatically adjusts to fit the parent container.

**Views**:

Switching brand-
<img width="1069" alt="Screenshot 2025-02-04 at 11 26 31 AM" src="https://github.com/user-attachments/assets/ff3abd65-12e1-4e26-b736-e05d8996dd5a" />
<img width="1078" alt="Screenshot 2025-02-04 at 11 26 56 AM" src="https://github.com/user-attachments/assets/60e9d444-9c52-4835-b72c-badfecd4e7ca" />

Dark View-
<img width="418" alt="Screenshot 2025-02-04 at 11 27 25 AM" src="https://github.com/user-attachments/assets/de599430-4842-4246-a310-eb6cfe6a9fd3" />
<img width="414" alt="Screenshot 2025-02-04 at 11 27 09 AM" src="https://github.com/user-attachments/assets/ddfb4f63-2b2f-4a0e-b0d8-33147afcdaa6" />
