### PR TITLE
[DE-32] Clean up main entry point and prepare dynamic search for navigating to components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.swiftpm/
+*.xcuserdatad/
+*.xcuserdata/
+xcuserdata/
+DerivedData/
+.build/
+Pods/
+*.DS_Store
+

--- a/ComponentLibrary/ComponentLibraryApp.swift
+++ b/ComponentLibrary/ComponentLibraryApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct ComponentLibraryApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ComponentLibraryHome()
         }
     }
 }

--- a/ComponentLibrary/ComponentLibraryHome.swift
+++ b/ComponentLibrary/ComponentLibraryHome.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct ComponentLibraryHome: View {
+    @State private var searchText = ""
+
+    let components: [(String, AnyView, String)] = [
+        ("Buttons", AnyView(ButtonView()), "rectangle.grid.1x2"),
+        ("ReliantFontsPage", AnyView(ReliantFontsPage()), "rectangle.fill.on.rectangle.fill"),
+    ]
+
+    var filteredComponents: [(String, AnyView, String)] {
+        if searchText.isEmpty {
+            return components
+        } else {
+            return components.filter { $0.0.lowercased().contains(searchText.lowercased()) }
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section(header: HeaderComponent(title: "NRG UI Components Library")) {
+                    ForEach(filteredComponents, id: \.0) { item in
+                        NavigationLink(destination: item.1) {
+                            HStack {
+                                Image(systemName: item.2)
+                                    .foregroundColor(.blue)
+                                    .frame(width: 30)
+                                Text(item.0)
+                                    .font(.headline)
+                                    .padding(.vertical, 8)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Component Library")
+            .searchable(text: $searchText, prompt: "Search Components")
+            .toolbar {
+                ToolbarItem(placement: .automatic) {
+                    Text("Component Library")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                }
+            }
+        }
+    }
+}

--- a/ComponentLibrary/Components/HeaderComponent.swift
+++ b/ComponentLibrary/Components/HeaderComponent.swift
@@ -1,0 +1,25 @@
+//
+//  HeaderComponent.swift
+//  ComponentLibrary
+//
+//  Created by UX/UI Development on 2/11/25.
+//
+
+import SwiftUI
+
+struct HeaderComponent: View {
+    let title: String
+
+    var body: some View {
+        HStack {
+            Text(title.uppercased())
+                .font(.caption)
+                .fontWeight(.bold)
+                .foregroundColor(.gray)
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.top, 10)
+        .background(Color.blue.opacity(0.1))
+    }
+}


### PR DESCRIPTION
### Fix DE-32
Link to ticket: https://de-ui.atlassian.net/browse/DE-32

### What has been done
- The main screen was created with searchable navigation to a component.
- List view of all components 
- Header component created 


<img width="888" alt="image" src="https://github.com/user-attachments/assets/db2b3732-9f74-4fec-a477-aee0784ca9be" />

