### PR TITLE
[DE-35] Adjusted ButtonSize as an optional

### DIFF
--- a/ComponentLibrary/ComponentLibraryHome.swift
+++ b/ComponentLibrary/ComponentLibraryHome.swift
@@ -2,10 +2,13 @@ import SwiftUI
 
 struct ComponentLibraryHome: View {
     @State private var searchText = ""
-
     let components: [(String, AnyView, String)] = [
         ("Buttons", AnyView(ButtonView()), "rectangle.grid.1x2"),
-        ("ReliantFontsPage", AnyView(ReliantFontsPage()), "rectangle.fill.on.rectangle.fill"),
+        ("Links", AnyView(LinkPage()), "rectangle.grid.1x2"),
+        ("ColorTokenSystem", AnyView(ColorSwatches()), "rectangle.fill.on.rectangle.fill"),
+        ("TypographyTokenSystem", AnyView(ReliantFontsPage()), "rectangle.fill.on.rectangle.fill"),
+        ("BorderTokenSystem", AnyView(ReliantBorderPage()), "rectangle.fill.on.rectangle.fill"),
+        ("SpacingTokenSystem", AnyView(SpacingPage()), "rectangle.fill.on.rectangle.fill"),
     ]
 
     var filteredComponents: [(String, AnyView, String)] {
@@ -44,5 +47,11 @@ struct ComponentLibraryHome: View {
                 }
             }
         }
+    }
+}
+
+struct ComponentLibraryHome_Previews: PreviewProvider {
+    static var previews: some View {
+        ComponentLibraryHome()
     }
 }

--- a/ComponentLibrary/Components/ButtonComponent.swift
+++ b/ComponentLibrary/Components/ButtonComponent.swift
@@ -4,8 +4,9 @@ enum ButtonVariant: CaseIterable {
     case primary, secondary, tertiary, disabled
 }
 
+
 enum ButtonSize {
-    case `default`, small
+    case small
 }
 
 
@@ -97,14 +98,14 @@ struct ButtonComponent: View {
     let selectedBrand: Brand
     let title: String
     let variant: ButtonVariant
-    let size: ButtonSize
+    let size: ButtonSize?
     let action: () -> Void
 
     init(
         selectedBrand: Brand,
         title: String,
         variant: ButtonVariant = .primary,
-        size: ButtonSize = .default,
+        size: ButtonSize? = nil,
         action: @escaping () -> Void = {}
     ) {
         self.selectedBrand = selectedBrand
@@ -116,6 +117,15 @@ struct ButtonComponent: View {
 
     var body: some View {
         let styleConfig = ButtonStyleConfig.get(for: selectedBrand, variant: variant, colorScheme: colorScheme)
+        
+        let buttonMaxWidth: CGFloat? = {
+                 switch size {
+                 case .small:
+                     return 156
+                 case .none:
+                     return .infinity
+                 }
+             }()
 
         Button(action: action) {
             Text(title)
@@ -124,7 +134,7 @@ struct ButtonComponent: View {
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.vertical, styleConfig.padding)
         }
-        .frame(maxWidth: size == .default ? .infinity : 156)
+        .frame(maxWidth: buttonMaxWidth)
         .background(styleConfig.shape.fill(styleConfig.backgroundColor))
         .brandBorderOverlay(
             brand: selectedBrand,

--- a/ComponentLibrary/Components/CardComponent.swift
+++ b/ComponentLibrary/Components/CardComponent.swift
@@ -20,14 +20,12 @@ struct CardComponent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            // Header
             Text(title)
                 .font(.headline)
                 .fontWeight(.bold)
                 .foregroundColor(ColorToken.grayscale900.color( brand: selectedBrand,
                                                                 colorScheme: colorScheme))
 
-            // List of items
             ForEach(items, id: \.text) { item in
                 HStack(alignment: .top, spacing: 12) {
                     Image(systemName: item.icon)

--- a/ComponentLibrary/Components/LinkComponent.swift
+++ b/ComponentLibrary/Components/LinkComponent.swift
@@ -6,69 +6,75 @@
 //
 import SwiftUI
 
-// MARK: - Link Variants
+
 enum LinkVariant {
     case text
     case accordion(isExpanded: Bool)
 }
 
-// MARK: - Link Component
 struct LinkComponent: View {
     @Environment(\.colorScheme) private var colorScheme
 
-    let selectedBrand: Brand
-    let text: String
-    let variant: LinkVariant
-    let isInline: Bool
-    let action: () -> Void
+let selectedBrand: Brand
+let text: String
+let variant: LinkVariant
+let isInline: Bool
+let action: () -> Void
 
-    init(
-        selectedBrand: Brand,
-        text: String,
-        variant: LinkVariant,
-        isInline: Bool = false,
-        action: @escaping () -> Void = {}
-    ) {
-        self.selectedBrand = selectedBrand
-        self.text = text
-        self.variant = variant
-        self.isInline = isInline
-        self.action = action
-    }
-
-    var body: some View {
-        let style = LinkStyleConfig.get(for: selectedBrand, colorScheme: colorScheme)
-        
-        // Create a base Text view.
-        let baseText = Text(text)
-        
-        Button(action: action) {
-            HStack(spacing: 4) {
-                // Use a Group to conditionally apply typographyStyle.
-                Group {
-                    if isInline {
-                        baseText
-                    } else {
-                        baseText.typographyStyle(style.typographyStyle, brand: selectedBrand)
-                    }
-                }
-                // Apply common modifiers.
-                .foregroundColor(style.foregroundColor)
-                .modifier(UnderlineModifier(applyUnderline: style.applyUnderline,
-                                            color: style.foregroundColor))
-                
-                // If this is an accordion variant, show the chevron.
-                if case let .accordion(isExpanded) = variant {
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .foregroundColor(style.foregroundColor)
-                }
-            }
-        }
-        .buttonStyle(.plain)
-    }
+init(
+    selectedBrand: Brand,
+    text: String,
+    variant: LinkVariant,
+    isInline: Bool = false,
+    action: @escaping () -> Void = {}
+) {
+    self.selectedBrand = selectedBrand
+    self.text = text
+    self.variant = variant
+    self.isInline = isInline
+    self.action = action
 }
 
-// MARK: - Link Style Config
+var body: some View {
+    let style = LinkStyleConfig.get(for: selectedBrand, colorScheme: colorScheme)
+    
+    Button(action: action) {
+        HStack(spacing: 4) {
+            createStyledText(style: style)
+
+            if case let .accordion(isExpanded) = variant {
+                accordionIcon(isExpanded: isExpanded, color: style.foregroundColor)
+            }
+        }
+    }
+    .buttonStyle(.plain)
+}
+
+// Extracts styling logic for the text
+private func createStyledText(style: LinkStyleConfig) -> some View {
+    let baseText = Text(text)
+
+    return Group {
+        if isInline {
+            baseText
+        } else {
+            baseText.typographyStyle(style.typographyStyle, brand: selectedBrand)
+        }
+    }
+    .foregroundColor(style.foregroundColor)
+    .modifier(UnderlineModifier(applyUnderline: style.applyUnderline, color: style.foregroundColor))
+}
+
+// Extracts accordion chevron icon logic
+private func accordionIcon(isExpanded: Bool, color: Color) -> some View {
+    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+        .foregroundColor(color)
+}
+}
+
+
+
+
 struct LinkStyleConfig {
 let foregroundColor: Color
 let applyUnderline: Bool

--- a/ComponentLibrary/Components/ModalComponent.swift
+++ b/ComponentLibrary/Components/ModalComponent.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CustomModalComponent: View {
-    @Binding var isPresented: Bool // Binding to close the modal
+    @Binding var isPresented: Bool 
 
     var body: some View {
         ZStack {

--- a/ComponentLibrary/Components/ToastComponent.swift
+++ b/ComponentLibrary/Components/ToastComponent.swift
@@ -27,14 +27,12 @@ struct ToastComponent: View {
                     Spacer()
                     
                     HStack(spacing: 20) {
-                        // Image
                         image
                             .resizable()
                             .scaledToFit()
                             .frame(width: 66, height: 66)
                             .clipShape(RoundedRectangle(cornerRadius: 8))
                         
-                        // Text
                         VStack(alignment: .leading, spacing: 10) {
                             Text(message)
                                 .foregroundColor(ColorToken.grayscale000.color( brand: selectedBrand,
@@ -42,14 +40,12 @@ struct ToastComponent: View {
                                 .font(.subheadline)
                                 .multilineTextAlignment(.leading)
                             
-                            // Clickable link
                             Button(action: linkAction) {
                                 linkText
                             }
                         }
 
                         
-                        // Close button
                         Button(action: {
                             withAnimation {
                                 isVisible = false
@@ -70,7 +66,6 @@ struct ToastComponent: View {
                 .transition(.move(edge: .bottom))
                 .animation(.easeInOut, value: isVisible)
                 .onAppear {
-   // Schedule hiding the toast based on `duration`
                     DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
                         withAnimation {
                             isVisible = false

--- a/ComponentLibrary/Managers/BorderTokenManager.swift
+++ b/ComponentLibrary/Managers/BorderTokenManager.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-// MARK: - Manager
+
 class BorderManager: ObservableObject {
     static let shared = BorderManager()
     

--- a/ComponentLibrary/Managers/ColorTokenManager.swift
+++ b/ComponentLibrary/Managers/ColorTokenManager.swift
@@ -6,19 +6,18 @@
 //
 
 import SwiftUI
-import os.log // for logging purposes. Good practice just in case we run into issues
+import os.log
  
  
 final class ColorTokenManager: ObservableObject {
     static let shared = ColorTokenManager()
    // Add @Published usually paired with Observable Object  making intergration with swift state manangement easy. Helps notify prop changes to other views or objects
-    @Published private(set) var tokens: AllBrandTokens? // Color tokens loaded from JSON
+    @Published private(set) var tokens: AllBrandTokens?
  
     private init() {
         loadColorTokens()
     }
  
-    // Loads the `ColorTokens.json` file and decodes it into `AllBrandTokens`.
     private func loadColorTokens() {
         guard let url = Bundle.main.url(forResource: "ColorTokens", withExtension: "json") else {
             os_log(.error, "ColorTokens.json not found in the app bundle.")
@@ -33,28 +32,19 @@ final class ColorTokenManager: ObservableObject {
         }
     }
  
-    // Returns the SwiftUI `Color` for a specific brand, token, and color scheme.
-    // - Parameters:
-    //   - brand: The brand name ("brandDE", "brandReliant").
-    //   - tokenName: The name of the color token.
-    //   - colorScheme: The current color scheme (`.light` or `.dark`).
-    //- Returns: A `Color` object or a default gray color if no match is found.
     func color(for brand: Brand, tokenName: String, colorScheme: ColorScheme) -> Color {
         guard tokens != nil else  {
             os_log(.error, "Color tokens not loaded. Returning default gray color.")
             return .gray
         }
  
-        // Retrieve themes for the brand
         guard let brandThemes = themes(for: brand) else {
             os_log(.error, "Invalid brand name: %@", brand.identifier)
             return .gray
         }
  
-        // Select the theme (light or dark)
         let themeColors = colorScheme == .light ? brandThemes.light : brandThemes.dark
  
-        // Retrieve the color token's hex value
         guard let hexValue = themeColors.colors[tokenName] else {
             os_log(.error, "Token name '%@' not found for brand: %@", tokenName, brand.identifier)
             return .gray
@@ -63,9 +53,6 @@ final class ColorTokenManager: ObservableObject {
         return Color(hex: hexValue) ?? .gray
     }
  
-    /// Retrieves themes for the specified brand.
-    /// - Parameter brand: The name of the brand.
-    /// - Returns: The `BrandThemes` object or `nil` if the brand is invalid.
     private func themes(for brand: Brand) -> BrandThemes? {
         guard let tokens = tokens else { return nil }
 

--- a/ComponentLibrary/Managers/TypographyTokenManager.swift
+++ b/ComponentLibrary/Managers/TypographyTokenManager.swift
@@ -35,7 +35,6 @@ final class TypographyTokenManager: ObservableObject {
     
     func font(for brand: Brand, styleName: String) -> Font {
             guard let styleToken = tokens?.value(for: brand, style: styleName) else {
-                // fallback if style or brand not found
                 return .system(size: 16)
             }
             var font = Font.custom(styleToken.fontName, size: styleToken.fontSize)
@@ -60,7 +59,6 @@ final class TypographyTokenManager: ObservableObject {
             return styleToken.lineHeight - styleToken.fontSize
         }
         
-        // MARK: - Private
         
         private func fontWeight(from str: String) -> Font.Weight? {
             switch str.lowercased() {

--- a/ComponentLibrary/Models/BorderTokenModels.swift
+++ b/ComponentLibrary/Models/BorderTokenModels.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-// MARK: - Models
 struct BorderBrandTokens: Decodable {
     let brands: [String: BrandBorderTokens]
 }
@@ -33,7 +32,6 @@ struct BorderRadius: Decodable {
     let full: CGFloat
 }
 
-// MARK: - Enums
 enum BorderStrokeKey {
     case none, thin, regular, thick, bar
 }
@@ -42,7 +40,6 @@ enum BorderRadiusKey {
     case none, xs, s, m, full
 }
 
-// MARK: - BrandBorderTokens extension to fetch numeric values
 extension BrandBorderTokens {
     func strokeValue(_ key: BorderStrokeKey) -> CGFloat {
         switch key {
@@ -75,9 +72,8 @@ extension BrandBorderTokens {
     }
 }
 
-// MARK: - SwiftUI View Extensions
+
 extension View {
-    // Adds an overlay of a RoundedRectangle with brand-specific corner radius & stroke width.
     func brandBorderOverlay(
         brand: Brand,
         radiusKey: BorderRadiusKey,

--- a/ComponentLibrary/Models/ColorToken.swift
+++ b/ComponentLibrary/Models/ColorToken.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 enum ColorToken: String {
-    //Shared token list as cases
+    //Shared token list
     case primaryBase
     case primaryDarkest
     case primaryLighter

--- a/ComponentLibrary/Models/ColorTokenModels.swift
+++ b/ComponentLibrary/Models/ColorTokenModels.swift
@@ -12,13 +12,11 @@ struct ThemeColors: Decodable {
 }
 
 
-// Represents the "light" and "dark" themes for a single brand.
 struct BrandThemes: Decodable {
     let light: ThemeColors
     let dark: ThemeColors
 }
 
-// Represents all brands at the top level of the JSON.
 struct AllBrandTokens: Decodable {
     let brandDE: BrandThemes
     let brandReliant: BrandThemes

--- a/ComponentLibrary/Models/SpacingTokenModels.swift
+++ b/ComponentLibrary/Models/SpacingTokenModels.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 import Foundation
 
-// Spacing Design Token Models
+
 struct SpacingSystem: Codable {
     let brands: [String: BrandSpacing]
 }
@@ -17,7 +17,6 @@ struct BrandSpacing: Codable {
     let containerSpacing: ContainerSpacing
 }
 
-// Page Spacing Tokens
 struct PageLayout: Codable {
     let margins: Margins
     let heights: Heights
@@ -37,7 +36,6 @@ struct SectionSpacing: Codable {
     let none, xs, s, m, l, xl, twoXL, threeXL, button: CGFloat
 }
 
-// Container Spacing Tokens
 struct ContainerSpacing: Codable {
     let padding: ContainerPadding
     let gaps: ContainerGaps

--- a/ComponentLibrary/Models/TypographyToken.swift
+++ b/ComponentLibrary/Models/TypographyToken.swift
@@ -19,7 +19,6 @@ enum MyTextStyle: String {
 extension View {
     func typographyStyle(_ style: MyTextStyle, brand: Brand) -> some View {
         let manager = TypographyTokenManager.shared
-        // Pass brand directly instead of brand.identifier
         let styleToken = manager.tokens?.value(for: brand, style: style.rawValue)
         
         let font = manager.font(for: brand, styleName: style.rawValue)

--- a/ComponentLibrary/Models/TypographyTokenModels.swift
+++ b/ComponentLibrary/Models/TypographyTokenModels.swift
@@ -19,7 +19,6 @@ struct TypographyTokens: Decodable {
     let brandDE: [String: TextStyleToken]
     let brandReliant: [String: TextStyleToken]
     
-    // Helper method to retrieve a token by brand + style key.
     func value(for brand: Brand, style: String) -> TextStyleToken? {
         switch brand {
         case .de:

--- a/ComponentLibrary/Pages/AnotherBrandPage.swift
+++ b/ComponentLibrary/Pages/AnotherBrandPage.swift
@@ -11,7 +11,6 @@ struct AnotherBrandPage: View {
  
     @Environment(\.colorScheme) var colorScheme
     
-    // Use Reliant brand color tokens
     @State private var selectedBrand: Brand = .reliant
     
     
@@ -32,29 +31,25 @@ struct AnotherBrandPage: View {
                                                                                    colorScheme: colorScheme))
                                 .font(.system(size: 32, weight: .heavy))
                 
-                //Typography token system test samples for Reliant
                 Text("Heading 1")
                                 .typographyStyle(.h1,  brand: selectedBrand)
                             
-                            //  Paragraph
-                            Text("Paragraph text")
+
+                Text("Paragraph text")
                                 .typographyStyle(.p1,  brand: selectedBrand)
-                            
-                            // Inline Link
+
                 Text("Link text underlined!")
                             .foregroundColor(ColorToken.primaryBase.color( brand: selectedBrand,
                                                                              colorScheme: colorScheme))
                             .typographyStyle(.p1, brand: selectedBrand)
                             
 
-                            // Primary button text
                             Text("Primary button text")
                                 .typographyStyle(.primaryButton, brand: selectedBrand)
                                 .padding()
                                 .background(ColorToken.containerFillPrimaryBrand.color( brand: selectedBrand,colorScheme: colorScheme))
                                 .cornerRadius(8)
                 
-                // Card View
                 CardComponent(
                                     title: "Steps for Completing Your Setup",
                                     items:cardItemsTwo,

--- a/ComponentLibrary/Pages/AnotherPage.swift
+++ b/ComponentLibrary/Pages/AnotherPage.swift
@@ -24,8 +24,6 @@ struct AnotherPage: View {
     var body: some View {
         ZStack {
             VStack {
-                
-                // Card View
                 CardComponent(
                                     title: "Steps for Completing Your Setup",
                                     items:cardItemsTwo,
@@ -42,9 +40,8 @@ struct AnotherPage: View {
                 }
                 .padding()
                 
-         
             }
-            // Toast View
+
             ToastComponent(
                 message: "Complete your Vivint offer!",
                 linkText: Text("Show Modal")
@@ -69,8 +66,4 @@ struct AnotherPage: View {
     }
 }
 
-//struct AnotherPage_Previews: PreviewProvider {
-//    static var previews: some View {
-//        AnotherPage()
-//    }
-//}
+

--- a/ComponentLibrary/Pages/ButtonPage.swift
+++ b/ComponentLibrary/Pages/ButtonPage.swift
@@ -20,8 +20,7 @@ struct ButtonView: View {
                     ButtonComponent(
                         selectedBrand: selectedBrand,
                         title: "Button show toast",
-                        variant: .primary,
-                        size: .default
+                        variant: .primary
                     ) {
                         withAnimation {
                             showToast = true
@@ -31,8 +30,7 @@ struct ButtonView: View {
                     ButtonComponent(
                         selectedBrand: selectedBrand,
                         title: "Button",
-                        variant: .secondary,
-                        size: .default
+                        variant: .secondary
                     ) {
                         print("Secondary tapped")
                     }
@@ -40,8 +38,7 @@ struct ButtonView: View {
                     ButtonComponent(
                         selectedBrand: selectedBrand,
                         title: "Button",
-                        variant: .tertiary,
-                        size: .default
+                        variant: .tertiary
                     ) {
                         print("Tertiary tapped")
                     }
@@ -49,11 +46,9 @@ struct ButtonView: View {
                     ButtonComponent(
                         selectedBrand: selectedBrand,
                         title: "Button",
-                        variant: .disabled,
-                        size: .default
+                        variant: .disabled
                     )
                     
-                    // Small-sized buttons
                     ButtonComponent(
                         selectedBrand: selectedBrand,
                         title: "Small Button",

--- a/ComponentLibrary/Pages/ButtonPage.swift
+++ b/ComponentLibrary/Pages/ButtonPage.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ButtonView: View {
     @State private var showToast = false
     @Environment(\.colorScheme) var colorScheme
-
     @State private var selectedBrand: Brand = .reliant
     
     

--- a/ComponentLibrary/Pages/ColorSwatchesPage.swift
+++ b/ComponentLibrary/Pages/ColorSwatchesPage.swift
@@ -14,7 +14,6 @@ struct ColorSwatches: View {
     
     var body: some View {
         VStack(spacing: 16) {
-            // Row 1
             Text("Primary")
                 .font(.custom("NRGEffraApp-Light", size: 16))
             HStack(spacing: 16) {
@@ -47,7 +46,6 @@ struct ColorSwatches: View {
                
             }
             
-            // Row 2
             Text("Secondary")
                 .font(.custom("NRGEffraApp-Light", size: 16))
             HStack(spacing: 16) {
@@ -80,7 +78,6 @@ struct ColorSwatches: View {
                     .frame(width: 60, height: 60)
                 
             }
-            // Row 3
             Text("Tertiary")
                 .font(.custom("NRGEffraApp-Light", size: 16))
             HStack(spacing: 16) {
@@ -112,7 +109,7 @@ struct ColorSwatches: View {
                     .frame(width: 60, height: 60)
                 
             }
-            // Row 4
+
             Text("Red")
                 .font(.custom("NRGEffraApp-Light", size: 16))
             HStack(spacing: 16) {
@@ -143,7 +140,7 @@ struct ColorSwatches: View {
                     )
                     .frame(width: 60, height: 60)
             }
-            // Row 5
+
             Text("Green")
                 .font(.custom("NRGEffraApp-Light", size: 16))
             HStack(spacing: 16) {
@@ -174,7 +171,7 @@ struct ColorSwatches: View {
                     )
                     .frame(width: 60, height: 60)
             }
-            // Row 6
+
             Text("Yellow")
                 .font(.custom("NRGEffraApp-Light", size: 16))
             HStack(spacing: 16) {
@@ -206,7 +203,7 @@ struct ColorSwatches: View {
                     .frame(width: 60, height: 60)
             }
             
-            // Row 7
+
             Text("Grayscale")
                 .font(.custom("NRGEffraApp-Light", size: 16))
             HStack(spacing: 16) {
@@ -239,7 +236,6 @@ struct ColorSwatches: View {
             }
             
         }
-//        .padding()
     }
 }
 

--- a/ComponentLibrary/Pages/ContentView.swift
+++ b/ComponentLibrary/Pages/ContentView.swift
@@ -37,18 +37,15 @@ struct ContentView: View {
                         .font(.custom("Inter18pt-Light", size: 24))
    
                     
-                    // Typography token system test samples for Reliant
                     Text("Heading 1")
                                     .typographyStyle(.h1, brand: selectedBrand)
                     Text("Heading 2")
                                     .typographyStyle(.h2, brand: selectedBrand)
                                 
                                 
-                                // Paragraph
                                 Text("Paragraph text")
                                     .typographyStyle(.p1, brand: selectedBrand)
                                 
-                              // In-line Link
                                     Text("Link text underlined!")
                                                 .underline()
                                                 .foregroundColor(ColorToken.primaryDarkest.color( brand: selectedBrand,
@@ -57,7 +54,6 @@ struct ContentView: View {
                                 
           
                                 
-                                //  Primary button text
                                 Text("Primary button text")
                                     .typographyStyle(.primaryButton, brand: selectedBrand)
                                     .padding()
@@ -79,7 +75,6 @@ struct ContentView: View {
                     }
                     
                     
-                    // Card View
                     CardComponent(
                                         title: "What should I expect when I enroll in Home Base Essentials?",
                                         items: cardItems,
@@ -95,7 +90,6 @@ struct ContentView: View {
                 }
                 
                 
-                // Toast View
                 ToastComponent(
                     message: "Complete your Vivint offer by scheduling your installation.",
                     linkText: Text("Schedule installation") .font(.subheadline)
@@ -121,14 +115,14 @@ struct ContentView: View {
                 case "AnotherBrandPage":
                     AnotherBrandPage()
                 default:
-                    EmptyView() // fallback
+                    EmptyView()
                 }
             }
 
         }
     }
     
-    // Cross-platform way to open a webpage in SwiftUI
+
      func openWebPage(_ urlString: String) {
          guard let url = URL(string: urlString) else {
              print("Invalid URL: \(urlString)")

--- a/ComponentLibrary/Pages/DeBorderPage.swift
+++ b/ComponentLibrary/Pages/DeBorderPage.swift
@@ -9,10 +9,7 @@
 import SwiftUI
 
 struct DeBorderPage: View {
- 
     @Environment(\.colorScheme) var colorScheme
-  
-
     @State private var selectedBrand: Brand = .de
     
     var body: some View {
@@ -31,7 +28,7 @@ struct DeBorderPage: View {
                                                     color: .black
                                                 )
                     .padding()
-                // button
+
                 Button(action: {}) {
                             Text("Primary button")
                                 .font(.system(size: 16, weight: .medium))

--- a/ComponentLibrary/Pages/DeFontsPage.swift
+++ b/ComponentLibrary/Pages/DeFontsPage.swift
@@ -25,10 +25,8 @@ struct DeFontsPage: View {
                     .font(.custom("BasicSans-Light", size: 24))
                 Text("Test Heading 1")
                     .font(.custom("BasicSans-Bold", size: 28))
-                
                     .padding()
                 
-                //Typography token system test samples for Reliant
                 Text("Heading 1")
                    .typographyStyle(.h1,  brand: selectedBrand)
                 Text("Heading 2")
@@ -42,7 +40,6 @@ struct DeFontsPage: View {
                 Text("Heading 6")
                    .typographyStyle(.h6,  brand: selectedBrand)
                 
-                // Paragraph
                 Text("Paragraph 1")
                    .typographyStyle(.p1, brand: selectedBrand)
                 Text("Paragraph 2")
@@ -52,8 +49,6 @@ struct DeFontsPage: View {
                 
           
             
-                
-//                 In-line Link
                 Text("Link text underlined!")
                             .underline()
                             .foregroundColor(ColorToken.primaryDarkest.color( brand: selectedBrand,
@@ -62,25 +57,25 @@ struct DeFontsPage: View {
                 
 
                
-                // Primary button text
+
                 Text("Primary button text")
                    .typographyStyle(.primaryButton,  brand: selectedBrand)
                     .padding()
                     .background(ColorToken.containerFillTertiary1.color( brand: selectedBrand,colorScheme: colorScheme))
                     .cornerRadius(8)
-                // Secondary button text
+
                 Text("Secondary button text")
                    .typographyStyle(.secondaryButton, brand: selectedBrand)
                     .padding()
                     .background(ColorToken.containerFillSecondaryBrand.color( brand: selectedBrand,colorScheme: colorScheme))
                     .cornerRadius(8)
-                // Tertiary button text
+
                 Text("Tertiary button text")
                    .typographyStyle(.tertiaryButton, brand: selectedBrand)
                     .padding()
 
                     .cornerRadius(8)
-                // Disabled button text
+
                 Text("Disabled button text")
                    .typographyStyle(.primaryButton, brand: selectedBrand)
                     .padding()

--- a/ComponentLibrary/Pages/LinkPage.swift
+++ b/ComponentLibrary/Pages/LinkPage.swift
@@ -14,7 +14,6 @@ struct LinkPage: View {
         var body: some View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
-                    // 1. Standalone Link
                     Text("Standalone Link:")
                         .typographyStyle(.h3,  brand: selectedBrand)
                     LinkComponent(
@@ -29,7 +28,6 @@ struct LinkPage: View {
                     
                     Divider()
                     
-                    // 2. Inline Link (embedded in a sentence)
                     Text("Inline Link:")
                         .typographyStyle(.h3,  brand: selectedBrand)
                     HStack(alignment: .firstTextBaseline, spacing: 0) {
@@ -48,7 +46,6 @@ struct LinkPage: View {
                     
                     Divider()
                     
-                    // 3. Accordion Link (toggling without extra content)
                     Text("Accordion Link (No Extra Content):")
                         .typographyStyle(.h3,  brand: selectedBrand)
                     LinkComponent(
@@ -66,7 +63,6 @@ struct LinkPage: View {
                     
                     Divider()
                     
-                    // 4. Accordion Link with Additional Content
                     Text("Accordion Link (With Additional Content):")
                         .typographyStyle(.h3,  brand: selectedBrand)
                     VStack(alignment: .leading, spacing: 8) {
@@ -82,7 +78,6 @@ struct LinkPage: View {
                             }
                         )
                         if isAccordionExpandedWithContent {
-                            // Additional content shown when expanded.
                             Text("Here is some extra content revealed by the accordion link. It could be any view!")
                                 .typographyStyle(.p1,  brand: selectedBrand)
                                 .padding()

--- a/ComponentLibrary/Pages/ReliantBorderPage.swift
+++ b/ComponentLibrary/Pages/ReliantBorderPage.swift
@@ -110,23 +110,6 @@ struct ReliantBorderPage: View {
                                                     radiusKey: .full,
                                                     strokeKey: .thick,
                                                     color:ColorToken.secondaryBase.color( brand: selectedBrand,colorScheme: colorScheme) )
-                // button
-//                Button(action: {}) {
-//                            Text("Primary button")
-//                                .font(.system(size: 16, weight: .medium))
-//                                .padding(.horizontal, 24)
-//                                .padding(.vertical, 12)
-//                                .background(Color.blue)
-//                                .foregroundColor(.white)
-//                                .cornerRadius(8)
-//                                .brandBorderOverlay(
-//                                                    brand: selectedBrand,
-//                                                    radiusKey: .m,
-//                                                    strokeKey: .regular,
-//                                                    color: .black
-//                                                )
-//                        }
-//
             }
             .navigationTitle("ReliantBorderPage")
         }

--- a/ComponentLibrary/Pages/ReliantFontsPage.swift
+++ b/ComponentLibrary/Pages/ReliantFontsPage.swift
@@ -22,7 +22,6 @@ struct ReliantFontsPage: View {
                     .font(.custom("NRGEffraApp-Light", size: 24))
                     .padding()
                 
-                // Typography token system test samples for Reliant
                 Text("Heading 1")
                     .typographyStyle(.h1,  brand: selectedBrand)
                 Text("Heading 2")
@@ -36,7 +35,7 @@ struct ReliantFontsPage: View {
                 Text("Heading 6")
                     .typographyStyle(.h6,  brand: selectedBrand)
                 
-                // Paragraph
+
                 Text("Paragraph 1")
                     .typographyStyle(.p1,  brand: selectedBrand)
                 Text("Paragraph 2")
@@ -44,9 +43,7 @@ struct ReliantFontsPage: View {
                 Text("Paragraph 3")
                     .typographyStyle(.p1, brand: selectedBrand)
                 
-//                Text("link")
-//                    .typographyStyle(.link, brand: selectedBrand)
-                // Inline Link
+
                 Text("Link text underlined!").foregroundColor(ColorToken.primaryBase.color( brand: selectedBrand, colorScheme: colorScheme)).typographyStyle(.p1, brand: selectedBrand)
                 
                 Text("Primary button text").typographyStyle(.primaryButton,brand: selectedBrand).foregroundColor(ColorToken.grayscale000.color(brand: selectedBrand, colorScheme: colorScheme)).padding().background(ColorToken.primaryBase.color( brand: selectedBrand,colorScheme: colorScheme))

--- a/ComponentLibrary/Pages/SpacingPage.swift
+++ b/ComponentLibrary/Pages/SpacingPage.swift
@@ -116,8 +116,7 @@ struct SpacingPage: View {
                     ButtonComponent(
                         selectedBrand: selectedBrand,
                         title: "Button",
-                        variant: .primary,
-                        size: .default
+                        variant: .primary
                     ) {
                         print("Secondary tapped")
                     }

--- a/ComponentLibrary/Pages/SpacingPage.swift
+++ b/ComponentLibrary/Pages/SpacingPage.swift
@@ -13,20 +13,15 @@ struct SpacingPage: View {
     @Environment(\.colorScheme) var colorScheme
     @State private var selectedBrand: Brand = .reliant
     
-    // A computed property that fetches the spacing tokens based on the selectedBrand
     private var brandSpacing: BrandSpacing {
         SpacingManager.shared.spacing(for: selectedBrand)
     }
     
     var body: some View {
         VStack(spacing: 0) {
-            
             ScrollView {
-                
-                // Vertical stack controlling spacing between sections
                 VStack(spacing: brandSpacing.pageLayout.sectionSpacing.xl) {
                     
-                    // 1) "Thank you" block
                     VStack(spacing: brandSpacing.pageLayout.sectionSpacing.s) {
                         Image(systemName: "checkmark.circle")
                             .font(.system(size: 36))
@@ -39,16 +34,9 @@ struct SpacingPage: View {
                         Text("We are processing your sign up for <plan name>. Please check your email nrgtest1050 @nrg.com for confirmation.")
                             .typographyStyle(.p1,  brand: selectedBrand)
                     }
-                    // Some horizontal padding for content inside
                     .padding(.horizontal, brandSpacing.containerSpacing.padding.xl)
-//                    .brandBorderOverlay(
-//                                        brand: selectedBrand,
-//                                        radiusKey: .none,
-//                                        strokeKey: .thin,
-//                                        color:ColorToken.primaryBase.color( brand: selectedBrand,colorScheme: colorScheme) )
+
                     
-                    
-                    // 2) Confirmation Details Card
                     VStack(alignment: .leading,spacing: brandSpacing.containerSpacing.gaps.m) {
                         Text("Confirmation details Confirmation details").typographyStyle(.h3,  brand: selectedBrand)
                         Text("Request submitted on 01/01/2023").typographyStyle(.p1,  brand: selectedBrand)
@@ -59,16 +47,8 @@ struct SpacingPage: View {
                     .cornerRadius(8)
                     .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
                     .frame(width: .infinity, alignment: .leading)
-//                    .brandBorderOverlay(
-//                        brand: selectedBrand,
-//                        radiusKey: .none,
-//                        strokeKey: .thin,
-//                        color: ColorToken.primaryBase.color(brand: selectedBrand, colorScheme: colorScheme)
-//                    )
 
-                    
-                    
-                    // 3) Tab Row Example
+
                     HStack {
                         Text("Account").foregroundColor(.secondary)
                         Spacer()
@@ -80,19 +60,13 @@ struct SpacingPage: View {
                     }
                     .typographyStyle(.p1,  brand: selectedBrand)
                     .padding(.horizontal, brandSpacing.containerSpacing.padding.s)
-//                    .brandBorderOverlay(
-//                                        brand: selectedBrand,
-//                                        radiusKey: .none,
-//                                        strokeKey: .thin,
-//                                        color:ColorToken.primaryBase.color( brand: selectedBrand,colorScheme: colorScheme) )
                     
-                    // 4) Plan Details Card
                     VStack(alignment: .leading, spacing: brandSpacing.containerSpacing.gaps.m) {
                         
                         Text("2 FREE DAYS PER WEEK")
                             .typographyStyle(.h3,  brand: selectedBrand)
                         
-                        //   PlanChips
+
                         HStack(spacing: brandSpacing.containerSpacing.gaps.s) {
                             PlanChip(text: "12 months", brandSpacing: brandSpacing)
                             PlanChip(text: "Fixed rate", brandSpacing: brandSpacing)
@@ -106,7 +80,6 @@ struct SpacingPage: View {
                             .typographyStyle(.p1,  brand: selectedBrand)
                             .foregroundColor(.secondary)
                         
-                        // Badges
                         HStack(spacing: brandSpacing.containerSpacing.gaps.s) {
                             BadgeView(text: "Recommended",
                                       backgroundColor: ColorToken.tertiaryBase.color( brand: selectedBrand,colorScheme: colorScheme))
@@ -114,7 +87,6 @@ struct SpacingPage: View {
                                       backgroundColor: ColorToken.primaryBase.color( brand: selectedBrand,colorScheme: colorScheme) )
                         }.typographyStyle(.p3,  brand: selectedBrand)
                         
-                        // Price row
                         HStack {
                             Text("18.5¢/kWh")
                                 .typographyStyle(.h2,  brand: selectedBrand)
@@ -140,17 +112,7 @@ struct SpacingPage: View {
                             .fill(ColorToken.grayscale000.color(brand: selectedBrand, colorScheme: colorScheme))
                     )
                     .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
-//                    .brandBorderOverlay(
-//                                        brand: selectedBrand,
-//                                        radiusKey: .m,
-//                                        strokeKey: .thin,
-//                                        color:ColorToken.grayscale300.color( brand: selectedBrand,colorScheme: colorScheme) )
-                    
-                    
 
-                    
-                    
-                    // 5) Bottom Button
                     ButtonComponent(
                         selectedBrand: selectedBrand,
                         title: "Button",
@@ -160,22 +122,11 @@ struct SpacingPage: View {
                         print("Secondary tapped")
                     }
                     .padding(.horizontal, brandSpacing.containerSpacing.padding.m)
-//                    .brandBorderOverlay(
-//                                        brand: selectedBrand,
-//                                        radiusKey: .none,
-//                                        strokeKey: .thin,
-//                                        color:ColorToken.primaryBase.color( brand: selectedBrand,colorScheme: colorScheme) )
-//                    
                 }
-                // Add bottom margin
+
                 .padding(.bottom, brandSpacing.pageLayout.margins.bottom)
                 .padding(.horizontal, brandSpacing.pageLayout.margins.horizontal)
                 .padding(.top, brandSpacing.pageLayout.margins.top)
-//                .brandBorderOverlay(
-//                                    brand: selectedBrand,
-//                                    radiusKey: .m,
-//                                    strokeKey: .thin,
-//                                    color:ColorToken.tertiaryBase.color( brand: selectedBrand,colorScheme: colorScheme) )
                 
             }
         }
@@ -183,9 +134,7 @@ struct SpacingPage: View {
     }
 }
 
-// MARK: - Supporting Subviews
 
-/// A simple "chip" for e.g. "12 months" or "Fixed rate"
 struct PlanChip: View {
     let text: String
     let brandSpacing: BrandSpacing
@@ -200,7 +149,7 @@ struct PlanChip: View {
     }
 }
 
-// A basic "badge" for something like "Recommended" or "$200 bill credit"
+
 struct BadgeView: View {
     let text: String
     let backgroundColor: Color

--- a/ComponentLibrary/Utilities/Brands.swift
+++ b/ComponentLibrary/Utilities/Brands.swift
@@ -8,26 +8,19 @@
 import SwiftUI
 import Foundation
 
-
  
 // Represents different brands in the component library.
 enum Brand: String, CaseIterable {
     case de
-    case reliant // Example new brand
-
- 
-    /// Returns the brand's identifier as used in JSON.
+    case reliant
     var identifier: String {
         switch self {
         case .de: return "brandDE"
-        case .reliant: return "brandReliant" // Automatically maps to JSON key
+        case .reliant: return "brandReliant"
 
         }
     }
- 
-    // Creates a `Brand` from its identifier string.
-    // - Parameter identifier: The string identifier ("brandDE").
-    // - Returns: The corresponding `Brand` enum case, or `nil` if not found.
+
     static func from(identifier: String) -> Brand? {
         return Brand.allCases.first { $0.identifier == identifier }
     }

--- a/ComponentLibrary/Utilities/ColorHexExtensions.swift
+++ b/ComponentLibrary/Utilities/ColorHexExtensions.swift
@@ -7,10 +7,8 @@
 
 import SwiftUI
 
-// MARK: - Hex -> Color
-
+// Hex -> Color
 extension Color {
-    /// Initializes a SwiftUI `Color` from a hex string.
     init?(hex: String) {
         let sanitizedHex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var rgbValue: UInt64 = 0
@@ -20,12 +18,12 @@ extension Color {
  
         let length = sanitizedHex.count
         switch length {
-        case 6: // #RRGGBB
+        case 6:
             let r = Double((rgbValue & 0xFF0000) >> 16) / 255.0
             let g = Double((rgbValue & 0x00FF00) >> 8) / 255.0
             let b = Double(rgbValue & 0x0000FF) / 255.0
             self = Color(red: r, green: g, blue: b)
-        case 8: // #RRGGBBAA
+        case 8:
             let r = Double((rgbValue & 0xFF000000) >> 24) / 255.0
             let g = Double((rgbValue & 0x00FF0000) >> 16) / 255.0
             let b = Double((rgbValue & 0x0000FF00) >> 8) / 255.0

--- a/ComponentLibrary/Utilities/UnderlineModifier.swift
+++ b/ComponentLibrary/Utilities/UnderlineModifier.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-// MARK: - Underline Modifier
+
 struct UnderlineModifier: ViewModifier {
     let applyUnderline: Bool
     let color: Color


### PR DESCRIPTION
This PR updates ButtonSize in the ButtonComponent to be optional instead of using .default.

**Reasons**:

- Avoid storing “default” as a variable – “Default” should be a fallback behavior, not an explicit enum value.
- Use an optional type for size – This ensures a cleaner API, avoids unnecessary explicit defaults, and makes future extensions easier.