### PR TITLE
[DE-16] Developed a reusable Tag Component

### DIFF
--- a/ComponentLibrary/Components/TagComponent.swift
+++ b/ComponentLibrary/Components/TagComponent.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+struct TagView: View {
+    enum TagStyle {
+        case active(ColorToken)
+        case inactive, warning, success
+    }
+    
+    enum IconPosition {
+        case left, right
+    }
+    
+    let text: String
+    let style: TagStyle
+    let selectedBrand: Brand
+    let icon: Image?  // Optional icon
+    let iconPosition: IconPosition?  // Optional position
+
+    init(
+        text: String,
+        style: TagStyle,
+        selectedBrand: Brand,
+        icon: Image? = nil,   // Default is nil
+        iconPosition: IconPosition? = nil  // Default is nil
+    ) {
+        self.text = text
+        self.style = style
+        self.selectedBrand = selectedBrand
+        self.icon = icon
+        self.iconPosition = iconPosition
+    }
+    
+    @Environment(\.colorScheme) var colorScheme
+    @ObservedObject private var borderManager = BorderManager.shared
+
+    /// Corrected `cornerRadius` property
+    var cornerRadius: CGFloat {
+        if let borderTokens = borderManager.tokens(for: selectedBrand) {  // ✅ Fixed incorrect parameter
+            switch selectedBrand {
+            case .de:
+                return borderTokens.borderRadius.full
+            case .reliant:
+                return borderTokens.borderRadius.s
+            }
+        }
+        return 0 // Provide a default value if borderTokens is nil
+    }
+
+    /// Corrected `backgroundColor` property
+    var backgroundColor: Color {
+        switch style {
+        case .active(let colorToken):
+            return colorToken.color(brand: selectedBrand, colorScheme: colorScheme)
+        case .inactive:
+            return ColorToken.grayscale300.color(brand: selectedBrand, colorScheme: colorScheme)
+        case .warning:
+            return ColorToken.redLight.color(brand: selectedBrand, colorScheme: colorScheme)
+        case .success:
+            return ColorToken.greenLight.color(brand: selectedBrand, colorScheme: colorScheme)
+        }
+    }  // ✅ Corrected misplaced bracket
+
+    /// Corrected `textColor` property
+    var textColor: Color {
+        switch style {
+        case .active:
+            return ColorToken.grayscale000.color(brand: selectedBrand, colorScheme: colorScheme)
+        case .inactive:
+            return ColorToken.grayscale900.color(brand: selectedBrand, colorScheme: colorScheme)
+        case .warning:
+            return ColorToken.redAccessible.color(brand: selectedBrand, colorScheme: colorScheme)
+        case .success:
+            return ColorToken.greenBase.color(brand: selectedBrand, colorScheme: colorScheme)
+        }
+    }
+
+    /// The main `body` View
+    var body: some View {
+        HStack(spacing: 6) {
+            if let icon = icon, iconPosition == .left {
+                icon
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 14, height: 14)
+            }
+            
+            Text(text)
+                .font(.system(size: 13, weight: .medium))
+            
+            if let icon = icon, iconPosition == .right {
+                icon
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 16, height: 16)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 5)
+        .background(backgroundColor)
+        .foregroundColor(textColor)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+}
+

--- a/ComponentLibrary/Components/TagComponent.swift
+++ b/ComponentLibrary/Components/TagComponent.swift
@@ -44,7 +44,6 @@ struct TagView: View {
             return cornerMapping[selectedBrand] ?? 0
         }
 
-    /// Corrected `backgroundColor` property
     var backgroundColor: Color {
         switch style {
         case .active(let colorToken):
@@ -58,9 +57,6 @@ struct TagView: View {
         }
     }
     
- 
-
-    /// Corrected `textColor` property
     var textColor: Color {
         switch style {
         case .active:
@@ -74,7 +70,6 @@ struct TagView: View {
         }
     }
 
-    /// The main `body` View
     var body: some View {
         HStack(spacing: 6) {
             if let icon = icon, iconPosition == .left {

--- a/ComponentLibrary/Components/TagComponent.swift
+++ b/ComponentLibrary/Components/TagComponent.swift
@@ -33,18 +33,16 @@ struct TagView: View {
     @Environment(\.colorScheme) var colorScheme
     @ObservedObject private var borderManager = BorderManager.shared
 
-    /// Corrected `cornerRadius` property
     var cornerRadius: CGFloat {
-        if let borderTokens = borderManager.tokens(for: selectedBrand) {
-            switch selectedBrand {
-            case .de:
-                return borderTokens.borderRadius.full
-            case .reliant:
-                return borderTokens.borderRadius.s
-            }
+            guard let borderTokens = borderManager.tokens(for: selectedBrand) else { return 0 }
+            
+            let cornerMapping: [Brand: CGFloat] = [
+                .de: borderTokens.borderRadius.full,
+                .reliant: borderTokens.borderRadius.s
+            ]
+            
+            return cornerMapping[selectedBrand] ?? 0
         }
-        return 0 
-    }
 
     /// Corrected `backgroundColor` property
     var backgroundColor: Color {
@@ -58,7 +56,9 @@ struct TagView: View {
         case .success:
             return ColorToken.greenLight.color(brand: selectedBrand, colorScheme: colorScheme)
         }
-    }  // ✅ Corrected misplaced bracket
+    }
+    
+ 
 
     /// Corrected `textColor` property
     var textColor: Color {

--- a/ComponentLibrary/Components/TagComponent.swift
+++ b/ComponentLibrary/Components/TagComponent.swift
@@ -13,15 +13,15 @@ struct TagView: View {
     let text: String
     let style: TagStyle
     let selectedBrand: Brand
-    let icon: Image?  // Optional icon
-    let iconPosition: IconPosition?  // Optional position
+    let icon: Image?
+    let iconPosition: IconPosition?
 
     init(
         text: String,
         style: TagStyle,
         selectedBrand: Brand,
-        icon: Image? = nil,   // Default is nil
-        iconPosition: IconPosition? = nil  // Default is nil
+        icon: Image? = nil,
+        iconPosition: IconPosition? = nil
     ) {
         self.text = text
         self.style = style
@@ -35,7 +35,7 @@ struct TagView: View {
 
     /// Corrected `cornerRadius` property
     var cornerRadius: CGFloat {
-        if let borderTokens = borderManager.tokens(for: selectedBrand) {  // ✅ Fixed incorrect parameter
+        if let borderTokens = borderManager.tokens(for: selectedBrand) {
             switch selectedBrand {
             case .de:
                 return borderTokens.borderRadius.full
@@ -43,7 +43,7 @@ struct TagView: View {
                 return borderTokens.borderRadius.s
             }
         }
-        return 0 // Provide a default value if borderTokens is nil
+        return 0 
     }
 
     /// Corrected `backgroundColor` property

--- a/ComponentLibrary/Pages/ReliantTagPage.swift
+++ b/ComponentLibrary/Pages/ReliantTagPage.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct TagDemoPage: View {
+    @State private var selectedBrand: Brand = .reliant
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Tag Component Demo")
+                .typographyStyle(.h1, brand: selectedBrand)
+
+            VStack(spacing: 10) {
+                
+                    Text("Active Tags")
+                        .font(.headline)
+
+                    // Tag with an icon
+                    TagView(
+                        text: "Recommended",
+                        style: .active(ColorToken.tertiaryBase),
+                        selectedBrand: selectedBrand,
+                        icon: Image(systemName: "star.fill"),
+                        iconPosition: .left
+                    )
+
+                    // Tag without an icon
+                    TagView(
+                        text: "$200 Bill Credit",
+                        style: .active(ColorToken.primaryBase),
+                        selectedBrand: selectedBrand
+                    )
+                    
+                    // Tag without an icon=
+                    TagView(
+                        text: "Tag Label",
+                        style: .active(ColorToken.greenBase),
+                        selectedBrand: selectedBrand
+                    )
+
+                    Spacer().frame(height: 10)
+
+                    Text("Inactive Tags")
+                        .font(.headline)
+
+                    // Tag without an icon
+                    TagView(
+                        text: "Inactive",
+                        style: .inactive,
+                        selectedBrand: selectedBrand
+                    )
+
+                    Spacer().frame(height: 10)
+
+                    Text("Status Tags")
+                        .font(.headline)
+
+                    // Tag with an icon
+                    TagView(
+                        text: "-10%",
+                        style: .warning,
+                        selectedBrand: selectedBrand,
+                        icon: Image(systemName: "arrow.down"),
+                        iconPosition: .left
+                    )
+
+                    // Tag without an icon
+                    TagView(
+                        text: "+20%",
+                        style: .success,
+                        selectedBrand: selectedBrand,
+                        icon: Image(systemName: "arrow.up"),
+                        iconPosition: .left
+                    )
+                    
+                
+            }
+            .padding()
+        }
+        .padding()
+    }
+}
+
+struct TagDemoPage_Previews: PreviewProvider {
+    static var previews: some View {
+        TagDemoPage()
+    }
+}
+

--- a/ComponentLibrary/Pages/ReliantTagPage.swift
+++ b/ComponentLibrary/Pages/ReliantTagPage.swift
@@ -69,8 +69,6 @@ struct TagDemoPage: View {
                         icon: Image(systemName: "arrow.up"),
                         iconPosition: .left
                     )
-                    
-                
             }
             .padding()
         }

--- a/ComponentLibrary/Pages/ReliantTagPage.swift
+++ b/ComponentLibrary/Pages/ReliantTagPage.swift
@@ -12,7 +12,6 @@ struct TagDemoPage: View {
                     Text("Active Tags")
                         .font(.headline)
 
-                    // Tag with an icon
                     TagView(
                         text: "Recommended",
                         style: .active(ColorToken.tertiaryBase),
@@ -21,14 +20,12 @@ struct TagDemoPage: View {
                         iconPosition: .left
                     )
 
-                    // Tag without an icon
                     TagView(
                         text: "$200 Bill Credit",
                         style: .active(ColorToken.primaryBase),
                         selectedBrand: selectedBrand
                     )
                     
-                    // Tag without an icon=
                     TagView(
                         text: "Tag Label",
                         style: .active(ColorToken.greenBase),
@@ -40,7 +37,6 @@ struct TagDemoPage: View {
                     Text("Inactive Tags")
                         .font(.headline)
 
-                    // Tag without an icon
                     TagView(
                         text: "Inactive",
                         style: .inactive,
@@ -52,7 +48,6 @@ struct TagDemoPage: View {
                     Text("Status Tags")
                         .font(.headline)
 
-                    // Tag with an icon
                     TagView(
                         text: "-10%",
                         style: .warning,
@@ -61,7 +56,6 @@ struct TagDemoPage: View {
                         iconPosition: .left
                     )
 
-                    // Tag without an icon
                     TagView(
                         text: "+20%",
                         style: .success,


### PR DESCRIPTION
This PR includes the following changes:

Created a reusable Tag component for different brands with the following variants:
a) Active Tag
b) Inactive Separator
c)Status Tags

All the tags can have either left icon or right icon or none
Screenshots for the Tag Component Demo Page:
<img width="533" alt="image" src="https://github.com/user-attachments/assets/eda70a51-566c-458b-a950-1a742298dbaa" />
