### PR TITLE
DRAFT: [ DE-62 Confirmation Details Component] 

### DIFF
--- a/ComponentLibrary/ComponentLibraryHome.swift
+++ b/ComponentLibrary/ComponentLibraryHome.swift
@@ -10,6 +10,7 @@ struct ComponentLibraryHome: View {
         ("Input", AnyView(InputPage()), "rectangle.grid.1x2"),
         ("Stepper", AnyView(StepperPage()), "rectangle.grid.1x2"),
         ("Plan Card", AnyView(PlanCardPage()), "inset.filled.rectangle"),
+        ("Confirmation Details", AnyView(ConfirmationDetailsPage()), "inset.filled.rectangle"),
         ("Confirmation Page", AnyView(ConfirmationPage()), "dock.rectangle"),
         ("ColorTokenSystem", AnyView(ColorSwatches()), "rectangle.fill.on.rectangle.fill"),
         ("TypographyTokenSystem", AnyView(FontsPage()), "rectangle.fill.on.rectangle.fill"),

--- a/ComponentLibrary/Components/ConfirmationDetailsComponent.swift
+++ b/ComponentLibrary/Components/ConfirmationDetailsComponent.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+
+struct ConfirmationDetails: View , BrandStyleSupport {
+    @Environment(\.brand)  var brand
+    @Environment(\.colorScheme)  var colorScheme
+ 
+
+    let id = UUID()
+    let requestDate: String
+    let confirmationNumber: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: brandSpacing.pageLayout.sectionSpacing.s) {
+ 
+            Text("Confirmation details")
+                .typographyStyle(.h3)
+            
+   
+            VStack(alignment: .leading,spacing: brandSpacing.containerSpacing.gaps.xs) {
+                Text("Request submitted on")
+                    .typographyStyle(.h6)
+                Text(requestDate)
+                    .typographyStyle(.p1)
+            }
+            
+
+            VStack(alignment: .leading,spacing: brandSpacing.containerSpacing.gaps.xs) {
+                Text("Confirmation number")
+                    .typographyStyle(.h6)
+                Text(confirmationNumber)
+                    .typographyStyle(.p1)
+            }
+        }
+        .padding(brandSpacing.containerSpacing.padding.m)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(colorToken(.containerFillGray1))
+        .cornerRadius(cornerRadius.l)
+    }
+}

--- a/ComponentLibrary/Pages/ConfirmationDetailsPage.swift
+++ b/ComponentLibrary/Pages/ConfirmationDetailsPage.swift
@@ -1,0 +1,23 @@
+
+import SwiftUI
+
+struct ConfirmationDetailsPage: View {
+    
+    var body: some View {
+        VStack {
+                    ConfirmationDetails(
+                            requestDate: "01/01/2023",
+                            confirmationNumber: "0000000123456778901"
+                    )
+                }
+        .padding()
+    }
+}
+
+struct ConfirmationDetails_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewWrapper { brand in
+            ConfirmationDetailsPage()
+        }
+    }
+}


### PR DESCRIPTION
Created Confirmation Details Component for Reliant
DE's Figma design isn't ready yet

Screenshots:
<img width="353" alt="Screenshot 2025-03-27 at 10 35 00 AM" src="https://github.com/user-attachments/assets/b393281b-067e-4302-b545-3759663c13c8" />
<img width="374" alt="Screenshot 2025-03-27 at 10 35 12 AM" src="https://github.com/user-attachments/assets/ece4be1e-57a6-4696-b85a-de022567fd52" />
